### PR TITLE
Fix width of the badges

### DIFF
--- a/src/ts/badgeView.ts
+++ b/src/ts/badgeView.ts
@@ -7,11 +7,12 @@ export class BadgeView {
         merged : '6E5494',
         closed : 'BD2C00'
     };
-    issue: Issue;
 
-    constructor(issue: Issue/* badgeHeight, labelWidth */) {
-        this.issue = issue;
-    }
+    constructor(
+        private issue: Issue/* badgeHeight, labelWidth */,
+        private maxNumberLength: number,
+        private maxStateLength: number
+    ) {}
 
     get badgeWidth() {
         const iconSize = this.badgeHeight;
@@ -21,10 +22,10 @@ export class BadgeView {
         return BadgeView.BADGE_HEIGHT;
     }
     get numberWidth() { // not so correct :P
-        return 15 + this.issue.number.length * 9
+        return 15 + this.maxNumberLength * 9;
     }
     get stateWidth() { // not so correct :P
-        return 10 + this.issue.state.length * 7
+        return 10 + this.maxStateLength * 7;
     }
     get stateColor() {
         return BadgeView.stateColors[this.issue.state];

--- a/src/ts/inject.ts
+++ b/src/ts/inject.ts
@@ -22,6 +22,10 @@ function update() {
     pickupUrls().then((arg: any) => {
         const links: HTMLAnchorElement[] = arg.links;
         const issues: any[] = arg.issues;
+
+        const maxNumberLength = Math.max.apply(null, issues.map(i => i.number.toString().length));
+        const maxStateLength = Math.max.apply(null, issues.map(i => i.state.length));
+
         const svgMap = issues.reduce((svgMap, issueData) => {
             const user = issueData.assignee || issueData.user
             const issue = new Issue(
@@ -30,7 +34,7 @@ function update() {
                 (issueData.merged ? 'merged' : issueData.state),
                 user
             )
-            const badgeView = new BadgeView(issue)
+            const badgeView = new BadgeView(issue, maxNumberLength, maxStateLength)
             svgMap[issueData.html_url] = badgeView.render() + issueData.title;
             return svgMap;
         }, <any>{})


### PR DESCRIPTION
# Problem
Currently, the width of badges on a page may be different.
It would be better if they were aligned.
![](https://cdn-ak.f.st-hatena.com/images/fotolife/h/hatz48/20170323/20170323122302.png)

# Changes
This PullRequest has 2 changes:
- `update()` in inject.ts calculates `maxNumberLength` `maxStateLength` from issues and pass them to `BadgeView`
- `BadgeView` uses `maxNumberLength` `maxStateLength` to calculate `numberWidth` and `stateWidth`

# Example
Now badges are aligned! 😸 
![issue](https://cloud.githubusercontent.com/assets/1403842/24234083/dbf458dc-0fd9-11e7-8ec1-c0270a779333.png)
