### PR TITLE
HTML escape: issue title

### DIFF
--- a/src/ts/inject.ts
+++ b/src/ts/inject.ts
@@ -18,6 +18,14 @@ function pickupUrls() {
     })
 }
 
+function escapeHTML(str: string) {
+    return str.replace(/&/g, '&amp;')
+              .replace(/</g, '&lt;')
+              .replace(/>/g, '&gt;')
+              .replace(/"/g, '&quot;')
+              .replace(/'/g, '&#039;');
+}
+
 function update() {
     pickupUrls().then((arg: any) => {
         const links: HTMLAnchorElement[] = arg.links;
@@ -35,7 +43,7 @@ function update() {
                 user
             )
             const badgeView = new BadgeView(issue, maxNumberLength, maxStateLength)
-            svgMap[issueData.html_url] = badgeView.render() + issueData.title;
+            svgMap[issueData.html_url] = badgeView.render() + escapeHTML(issueData.title);
             return svgMap;
         }, <any>{})
 


### PR DESCRIPTION
# Problem
Now, the issue title is not HTML escaped:

<img width="780" alt="2017-04-03 18 32 07" src="https://cloud.githubusercontent.com/assets/1131623/24603478/e4f36dea-189b-11e7-8fcd-a89bb71f1e51.png">

# Changes

- implement `escapeHTML()`
- apply `escapeHTML()` function to issue title in `update()`

# Example

<img width="782" alt="2017-04-03 18 30 06" src="https://cloud.githubusercontent.com/assets/1131623/24603479/e9923a48-189b-11e7-9f5b-0a62d1719aa6.png">
