### PR TITLE
show all assignees' icon

### DIFF
--- a/src/ts/badgeView.ts
+++ b/src/ts/badgeView.ts
@@ -35,9 +35,9 @@ export class BadgeView {
         const iconSize = this.badgeHeight;
         const icons = this.issue.assignees.map((user, idx) => `
             <image x="${this.numberWidth + this.stateWidth + iconSize * idx}" y="0"
-                width="${iconSize}" height="${iconSize}"
-                xlink:href="${user.avatar_url}"></image>
-        `)
+                   width="${iconSize}" height="${iconSize}"
+                   xlink:href="${user.avatar_url}"></image>
+        `);
 
         return `<svg class="embed-badge" width="${this.badgeWidth}" height="${this.badgeHeight}" style="border-radius: 2px; vertical-align: middle; margin-right: 0.3em">
   <rect x="0" y="0" style="fill:#555"
@@ -47,7 +47,7 @@ export class BadgeView {
   <rect x="${this.numberWidth + this.stateWidth}" y="0" style="fill:#999"
         width="${this.badgeWidth}" height="${this.badgeHeight}" />
   <!-- TODO: labels -->
-  ${icons}
+  ${icons.join('')}
   <linearGradient id="cover" x1="0%" y1="0%" x2="0%" y2="100%">
     <stop offset="0%" stop-color="#bbb" stop-opacity="0.10"></stop>
     <stop offset="100%" stop-color="#000" stop-opacity="0.10"></stop>

--- a/src/ts/badgeView.ts
+++ b/src/ts/badgeView.ts
@@ -16,7 +16,7 @@ export class BadgeView {
 
     get badgeWidth() {
         const iconSize = this.badgeHeight;
-        return this.numberWidth + this.stateWidth + iconSize/* + this.labelWidth */
+        return this.numberWidth + this.stateWidth + ( iconSize * this.issue.assignees.length )/* + this.labelWidth */
     }
     get badgeHeight() {
         return BadgeView.BADGE_HEIGHT;
@@ -33,6 +33,12 @@ export class BadgeView {
 
     render() {
         const iconSize = this.badgeHeight;
+        const icons = this.issue.assignees.map((user, idx) => `
+            <image x="${this.numberWidth + this.stateWidth + iconSize * idx}" y="0"
+                width="${iconSize}" height="${iconSize}"
+                xlink:href="${user.avatar_url}"></image>
+        `)
+
         return `<svg class="embed-badge" width="${this.badgeWidth}" height="${this.badgeHeight}" style="border-radius: 2px; vertical-align: middle; margin-right: 0.3em">
   <rect x="0" y="0" style="fill:#555"
         width="${this.numberWidth}" height="${this.badgeHeight}" />
@@ -41,9 +47,7 @@ export class BadgeView {
   <rect x="${this.numberWidth + this.stateWidth}" y="0" style="fill:#999"
         width="${this.badgeWidth}" height="${this.badgeHeight}" />
   <!-- TODO: labels -->
-  <image x="${this.numberWidth + this.stateWidth}" y="0"
-        width="${iconSize}" height="${iconSize}"
-        xlink:href="${this.issue.assignee.avatar_url}"></image>
+  ${icons}
   <linearGradient id="cover" x1="0%" y1="0%" x2="0%" y2="100%">
     <stop offset="0%" stop-color="#bbb" stop-opacity="0.10"></stop>
     <stop offset="100%" stop-color="#000" stop-opacity="0.10"></stop>

--- a/src/ts/inject.ts
+++ b/src/ts/inject.ts
@@ -35,12 +35,12 @@ function update() {
         const maxStateLength = Math.max.apply(null, issues.map(i => i.state.length));
 
         const svgMap = issues.reduce((svgMap, issueData) => {
-            const user = issueData.assignee || issueData.user
+            const users = issueData.assignees.length > 0 ? issueData.assignees : [ issueData.user ]
             const issue = new Issue(
                 issueData.repository_url,
                 '#' + issueData.number,
                 (issueData.merged ? 'merged' : issueData.state),
-                user
+                users,
             )
             const badgeView = new BadgeView(issue, maxNumberLength, maxStateLength)
             svgMap[issueData.html_url] = badgeView.render() + escapeHTML(issueData.title);

--- a/src/ts/issue.ts
+++ b/src/ts/issue.ts
@@ -3,6 +3,6 @@ export class Issue {
         public repo: string,
         public number: string,
         public state: string,
-        public assignee: { avatar_url: string }
+        public assignees: [ { avatar_url: string } ]
     ) {}
 }


### PR DESCRIPTION
Github has supported multiple assignees on issues and pull requests.
But, this extension doesn't support multiple assignees.

I implemented to display all assignees icon:

# before
<img width="364" alt="2017-04-18 22 05 27" src="https://cloud.githubusercontent.com/assets/1131623/25132332/3069e3be-2484-11e7-87fb-189261a7d633.png">

# after
<img width="370" alt="2017-04-18 22 05 07" src="https://cloud.githubusercontent.com/assets/1131623/25132328/2d70bf70-2484-11e7-8514-8a91761f6018.png">
