### PR TITLE
Reset budge's font-weight ( /w fix for build with node v12 and later 🙏 )

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@types/react": "^15.0.21",
     "@types/react-dom": "^0.14.23",
     "del": "^0.1.3",
-    "gulp": "^3.8.8",
+    "gulp": "^4.0.2",
     "gulp-changed": "^1.0.0",
     "gulp-json-editor": "^2.1.0",
     "gulp-load-plugins": "^0.7.0",

--- a/src/ts/badgeView.ts
+++ b/src/ts/badgeView.ts
@@ -39,7 +39,7 @@ export class BadgeView {
                    xlink:href="${user.avatar_url}"></image>
         `);
 
-        return `<svg class="embed-badge" width="${this.badgeWidth}" height="${this.badgeHeight}" style="border-radius: 2px; vertical-align: middle; margin-right: 0.3em">
+        return `<svg class="embed-badge" width="${this.badgeWidth}" height="${this.badgeHeight}" style="font-weight: normal;border-radius: 2px; vertical-align: middle; margin-right: 0.3em">
   <rect x="0" y="0" style="fill:#555"
         width="${this.numberWidth}" height="${this.badgeHeight}" />
   <rect x="${this.numberWidth}" y="0" style="fill:#${this.stateColor}"


### PR DESCRIPTION
These days, Github has updated style with issue links to text with bold weight. 

Current release version

[![Image from Gyazo](https://i.gyazo.com/d31d239f724cb32bb6519e4241302506.png)](https://gyazo.com/d31d239f724cb32bb6519e4241302506)

This PR will make text in budge normal weight

[![Image from Gyazo](https://i.gyazo.com/7e591dcbc3ecbf3ac4ac9dfdca5fd581.png)](https://gyazo.com/7e591dcbc3ecbf3ac4ac9dfdca5fd581)

### This PR includes support with Node v12 and later 🙏 

- update gulp to v4